### PR TITLE
Moving Experience section to the bottom for each level

### DIFF
--- a/engineer1.md
+++ b/engineer1.md
@@ -23,12 +23,12 @@ I own work within the scope of my team with specific guidance from my manager an
 - Writes bug reports that are clear, concise, with reproducible steps
 - Monitors their team's alert channels and knows where in the code that alert fired from
 - Tunes alerts to reduce noise at the direction of the larger team
-	
-## Experience
-High level understanding of web architecture, databases and operating systems
 
 ## Example activity breakdown
 - 70% - Contribute Solutions with Code
 - 10% - Collaboration, Code Reviews, etc
 - 10% - Logistics such as planning, estimation, etc
 - 10% - Learn about and maintain best practices
+
+## Experience
+- High level understanding of web architecture, databases and operating systems

--- a/engineer2.md
+++ b/engineer2.md
@@ -23,13 +23,13 @@ I own work primarily within the scope of my team with high level guidance from m
 - Debugs complex issues within their primary system and straightforward issues in adjacent systems 
 - Identifies errors in their primary system and escalate to the team as needed
 
-## Experience
-- Contributed to multiple production codebases
-- Consistently deployed testing and good documentation standards
-- Displayed root cause analysis and coordination
-
 ## Example activity breakdown
 - 70% - Contribute Solutions with Code
 - 10% - Collaboration, Code Reviews, etc
 - 10% - Logistics such as planning, estimation, etc
 - 10% - Maintain best practices and resolve issues"
+
+## Experience
+- Contributed to multiple production codebases
+- Consistently deployed testing and good documentation standards
+- Displayed root cause analysis and coordination

--- a/engineer3.md
+++ b/engineer3.md
@@ -26,13 +26,13 @@ I own work primarily with my direct team and cross-functional partners while dri
 - Debugs complex issues across multiple systems with help from SMEs as needed
 - Proactively identifies issues using our error and application monitoring tools
 	
-## Experience
-- Refactored or scaled multiple production codebases
-- Fostered adoption of best practices, testing frameworks and/or documentation
-- T-shaped expertise in relevant and adjacent technologies
-
 ## Example activity breakdown
 - 70% - Design and Contribute Solutions with Code
 - 10% - Collaboration, Code Reviews, etc
 - 10% - Logistics such as planning, estimation, etc
 - 10% - Maintain best practices and resolve issues
+
+## Experience
+- Refactored or scaled multiple production codebases
+- Fostered adoption of best practices, testing frameworks and/or documentation
+- T-shaped expertise in relevant and adjacent technologies

--- a/senior_engineer.md
+++ b/senior_engineer.md
@@ -27,13 +27,13 @@ I increasingly optimize beyond just my team by driving cross-team or cross-disci
 - Strategizes the full cycle of monitoring from alerting, metrics, monitors, and tooling for at least 1 system
 - Improves the culture of debugging by utilizing debugging as a growth mechanism for less experienced developers
 
-## Experience
-- Lead, mentored or facilitated teams
-- Greenfield, startup or similar production codebase design
-- Experience bringing new technology into production
-
 ## Example activity breakdown
 - 60% - Facilitate, Create and Design Solutions with Code
 - 20% - Mentoring, Code Reviews, etc
 - 10% - Logistics such as planning, estimation, etc
 - 10% - Facilitate best practices and resolve issues
+
+## Experience
+- Lead, mentored or facilitated teams
+- Greenfield, startup or similar production codebase design
+- Experience bringing new technology into production


### PR DESCRIPTION
The experience section was at the bottom of the [old career ladder](https://docs.google.com/spreadsheets/d/1KlW3k9enD_dits2Y316E8lhgkBWB-UaC/edit?gid=1608689845#gid=1608689845) so I decided to move this section to the end for each level.

I find this 'Experience' section useful during hiring for identifying the types of candidate profile we are seeking, but it is less directly applicable to existing employees. Hence I think it should remain at the bottom