### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,15 +12,20 @@ Thank you for helping keep our engineering job descriptions clear, accurate, and
 These guidelines are aimed at engineering leaders at Outside to propose changes to the career ladder. 
 
 1. **Open a Pull Request**
-    - All edits must be made via PR
-    - Direct pushes to the `main` branch are disabled.
+    - All edits must be made via PR targetting the main branch
+    - Direct pushes to the `main` branch are disabled
 
-2. **Describe Your Changes**
-    - Use the PR description to explain what you changed and why.
+2. **Describe the Changes**
+    - Use the PR description to explain what you changed and why
 
-3. **Get 2 Approvals**
-    - Every PR must be approved by **at least two managers**.
+3. **Get Approvals**
+    - Request review from `eng-leads` group
+    - Does this change require executive approval? Use your judgement and tag @jennvoss as needed
+    - Every PR must be approved by **at least 3 managers**.
     - Reviewers should check for:
       - Does this reflect my current team and the roles they're in?
       - Is the criteria useful to frame career and performance conversations with current employees?
       - Are these behaviors that can be observed, taught and evaluated?
+
+4. **Merge the PR **
+   - The PR author is responsible for merging after approval


### PR DESCRIPTION
This is a proposal for contribution guidelines for engineering leaders (managers and tech leads) to contribute to this ladder in Github. 

Problem: During the process of editing the career ladder, we found that collaborating on a shared spreadsheet was incredibly time consuming, requiring many synchronous meetings to agree on changes to the doc.

Solution: I hope that clear guidelines for contribution will empower anyone in this group to propose changes, get feedback, and merge asynchronously; so that we can ship these updates sooner. As a bonus, each change will have a paper trail of discussion for context on why the change was made 