### PR TITLE
Remove "Miro" and replace with more generic "design diagram"

### DIFF
--- a/engineer1.md
+++ b/engineer1.md
@@ -6,7 +6,7 @@ I own work within the scope of my team with specific guidance from my manager an
 - Researches issues independently but also knows when to ask for help when after becoming blocked, and appropriately conveying the issue and research done
 
 ## Planning, Prioritization and Architecture
-- Reads and comments on technical solution planning artifacts (ie. RFCs, Miro)
+- Reads and comments on technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Works according to priority of their tasks
 - Designs functions, avoiding duplication across codebases and interface-breaking changes based on an understanding of the overall architecture
 	

--- a/engineer2.md
+++ b/engineer2.md
@@ -6,7 +6,7 @@ I own work primarily within the scope of my team with high level guidance from m
 - Knows how to navigate within your product's business unit to help solve or track down issues
 
 ## Planning, Prioritization and Architecture
-- Co-authors technical solution planning artifacts (ie. RFCs, Miro)
+- Co-authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates of individual tickets
 - Understands the priority of their tasks and acts accordingly
 - Design solutions (of x complexity) that are aligned with the overall architecture

--- a/engineer3.md
+++ b/engineer3.md
@@ -7,7 +7,7 @@ I own work primarily with my direct team and cross-functional partners while dri
 - Developing the skill to communicate technical concepts to non-technical audiences
 
 ## Planning, Prioritization and Architecture
-- Authors technical solution planning artifacts (ie. RFCs, Miro)
+- Authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates for both tickets and projects
 - Understands the priority of their tasks and acts accordingly
 - Designs solutions (of y complexity) that are aligned with the overall architecture

--- a/senior_engineer.md
+++ b/senior_engineer.md
@@ -8,7 +8,7 @@ I increasingly optimize beyond just my team by driving cross-team or cross-disci
 - Communicates technical concepts to non-technical audiences
 
 ## Planning, Prioritization and Architecture
-- Authors technical solution planning artifacts (ie. RFCs, Miro)
+- Authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates based off of tech debt, project priorities
 - Understands competing priorities and acts accordingly
 - Design solutions (of z complexity) that are aligned with the overall architecture


### PR DESCRIPTION
We should do our best to create a timeless career ladder.

Miro just happens to be our current diagramming product, but this could change in the future. 

