### PR TITLE
More distinction in Planning, Prioritization and Architecture for level 3 and senior

### DIFF
--- a/engineer2.md
+++ b/engineer2.md
@@ -12,7 +12,7 @@ I own work primarily within the scope of my team with high level guidance from m
 - Co-authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates of individual tickets
 - Understands the priority of their tasks and acts accordingly
-- Design solutions for projects with clear requirements and minimal risk that are aligned with the overall architecture
+- Design solutions for well defined problems following best practices of the codebase
 - Writes technical tasks with occasional guidance
 
 ## Technical Contributions

--- a/engineer2.md
+++ b/engineer2.md
@@ -12,7 +12,7 @@ I own work primarily within the scope of my team with high level guidance from m
 - Co-authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates of individual tickets
 - Understands the priority of their tasks and acts accordingly
-- Design solutions of low complexity that are aligned with the overall architecture
+- Design solutions for projects with clear requirements and minimal risk that are aligned with the overall architecture
 - Writes technical tasks with occasional guidance
 
 ## Technical Contributions

--- a/engineer2.md
+++ b/engineer2.md
@@ -1,18 +1,22 @@
 ## Scope
+
 I own work primarily within the scope of my team with high level guidance from my manager and engineering lead
 
 ## Collaboration and Communication
+
 - Communicates effectively with immediate and dependent teams and stakeholders
 - Knows how to navigate within your product's business unit to help solve or track down issues
 
 ## Planning, Prioritization and Architecture
+
 - Co-authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates of individual tickets
 - Understands the priority of their tasks and acts accordingly
-- Design solutions (of x complexity) that are aligned with the overall architecture
+- Design solutions of low complexity that are aligned with the overall architecture
 - Writes technical tasks with occasional guidance
 
 ## Technical Contributions
+
 - Writes readable code following best practices of the team
 - Expands test coverage where necessary
 - Writes code reviews reviews that are helpful and valuable to the team
@@ -20,16 +24,19 @@ I own work primarily within the scope of my team with high level guidance from m
 - Makes consistent progress on solutions and leverage best practices
 
 ## Debugging & Monitoring
-- Debugs complex issues within their primary system and straightforward issues in adjacent systems 
+
+- Debugs complex issues within their primary system and straightforward issues in adjacent systems
 - Identifies errors in their primary system and escalate to the team as needed
 
 ## Example activity breakdown
+
 - 70% - Contribute Solutions with Code
 - 10% - Collaboration, Code Reviews, etc
 - 10% - Logistics such as planning, estimation, etc
 - 10% - Maintain best practices and resolve issues"
 
 ## Experience
+
 - Contributed to multiple production codebases
 - Consistently deployed testing and good documentation standards
 - Displayed root cause analysis and coordination

--- a/engineer3.md
+++ b/engineer3.md
@@ -13,7 +13,7 @@ I own work primarily with my direct team and cross-functional partners while dri
 - Lead co-author of technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates for both tickets and projects
 - Understands the priority of their tasks and acts accordingly
-- Designs solutions of medium complexity that are aligned with the overall architecture
+- Designs solutions for projects with some ambiguity or moderate risk that are aligned with the overall architecture
 - Breaks initiatives into smaller tasks that can be understood by non-technical parties
 - Assists with technical discovery during planning to reduce ambiguity
 

--- a/engineer3.md
+++ b/engineer3.md
@@ -1,38 +1,45 @@
 ## Scope
+
 I own work primarily with my direct team and cross-functional partners while driving cross-team collaboration for my project
 
 ## Collaboration and Communication
+
 - Communicates effectively with immediate and dependent teams and stakeholders
 - Attends and/or facilitate meetings with stakeholders to gather or ask technical questions without reliance on EM or PM
 - Developing the skill to communicate technical concepts to non-technical audiences
 
 ## Planning, Prioritization and Architecture
+
 - Authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates for both tickets and projects
 - Understands the priority of their tasks and acts accordingly
-- Designs solutions (of y complexity) that are aligned with the overall architecture
+- Designs solutions of medium complexity that are aligned with the overall architecture
 - Breaks initiatives into smaller tasks that can be understood by non-technical parties
 - Assists with technical discovery during planning to reduce ambiguity
-	
+
 ## Technical Contributions
-- Writes readable and optimized code. Uses best practices of the language, when team best practices are ambiguous, 
-- Contributes to unit tests and E2E tests 
+
+- Writes readable and optimized code. Uses best practices of the language, when team best practices are ambiguous,
+- Contributes to unit tests and E2E tests
 - Writes code reviews that are informative, maintain best practices, timely, and thorough
 - Creates and shares currated documentation
 - Makes consistent progresss on medium-to-large solutions and leverage best practices
 - Subject matter expert of multiple areas of the code base or tools
-	
+
 ## Debugging & Monitoring
+
 - Debugs complex issues across multiple systems with help from SMEs as needed
 - Proactively identifies issues using our error and application monitoring tools
-	
+
 ## Example activity breakdown
+
 - 70% - Design and Contribute Solutions with Code
 - 10% - Collaboration, Code Reviews, etc
 - 10% - Logistics such as planning, estimation, etc
 - 10% - Maintain best practices and resolve issues
 
 ## Experience
+
 - Refactored or scaled multiple production codebases
 - Fostered adoption of best practices, testing frameworks and/or documentation
 - T-shaped expertise in relevant and adjacent technologies

--- a/engineer3.md
+++ b/engineer3.md
@@ -13,7 +13,7 @@ I own work primarily with my direct team and cross-functional partners while dri
 - Lead co-author of technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates for both tickets and projects
 - Understands the priority of their tasks and acts accordingly
-- Designs solutions for projects with some ambiguity or moderate risk that are aligned with the overall architecture
+- Designs solutions for problems of moderate ambiguity/complexity that are aligned with the overall architecture
 - Breaks initiatives into smaller tasks that can be understood by non-technical parties
 - Assists with technical discovery during planning to reduce ambiguity
 

--- a/engineer3.md
+++ b/engineer3.md
@@ -10,7 +10,7 @@ I own work primarily with my direct team and cross-functional partners while dri
 
 ## Planning, Prioritization and Architecture
 
-- Lead co-author of technical solution planning artifacts (ie. RFCs, Design Diagrams)
+- Co-author of technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates for both tickets and projects
 - Understands the priority of their tasks and acts accordingly
 - Designs solutions for problems of moderate ambiguity/complexity that are aligned with the overall architecture

--- a/engineer3.md
+++ b/engineer3.md
@@ -10,7 +10,7 @@ I own work primarily with my direct team and cross-functional partners while dri
 
 ## Planning, Prioritization and Architecture
 
-- Authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
+- Lead co-author of technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates for both tickets and projects
 - Understands the priority of their tasks and acts accordingly
 - Designs solutions of medium complexity that are aligned with the overall architecture

--- a/senior_engineer.md
+++ b/senior_engineer.md
@@ -1,21 +1,25 @@
 ## Scope
+
 I increasingly optimize beyond just my team by driving cross-team or cross-discipline initiatives - owning work in and adjacent to my primary domain
 
 ## Collaboration and Communication
+
 - Communicates effectively with immediate and dependent teams and stakeholders
 - Communicates with the organization, helps others in team to communicate
 - Attends and/or facilitates meetings with stakeholders to gather or ask technical questions without reliance on EM or PM
 - Communicates technical concepts to non-technical audiences
 
 ## Planning, Prioritization and Architecture
+
 - Authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates based off of tech debt, project priorities
 - Understands competing priorities and acts accordingly
-- Design solutions (of z complexity) that are aligned with the overall architecture
+- Design solutions of high complexity that are aligned with the overall architecture
 - Assists with technical discovery during planning to reduce ambiguity
 - Influences product roadmap by bringing technical insight and aligning engineering priorities with business goals
 
 ## Technical Contributions
+
 - Develops coding best practices for the team and utilizes automation where possible to enforce best practices
 - Manages, contributes, and performs upkeep on unit tests & E2E tests
 - Writes code review feedback that is timely, sought after and respected, and often the source of others’ learning
@@ -23,17 +27,20 @@ I increasingly optimize beyond just my team by driving cross-team or cross-disci
 - Begins to delegate tasks, or pair programs on tasks for the purpose of knowledge sharing with other engineers
 
 ## Debugging & Monitoring
+
 - Debugs the toughest issues. Capable of weighing solutions against constraints
 - Strategizes the full cycle of monitoring from alerting, metrics, monitors, and tooling for at least 1 system
 - Improves the culture of debugging by utilizing debugging as a growth mechanism for less experienced developers
 
 ## Example activity breakdown
+
 - 60% - Facilitate, Create and Design Solutions with Code
 - 20% - Mentoring, Code Reviews, etc
 - 10% - Logistics such as planning, estimation, etc
 - 10% - Facilitate best practices and resolve issues
 
 ## Experience
+
 - Lead, mentored or facilitated teams
 - Greenfield, startup or similar production codebase design
 - Experience bringing new technology into production

--- a/senior_engineer.md
+++ b/senior_engineer.md
@@ -13,7 +13,7 @@ I increasingly optimize beyond just my team by driving cross-team or cross-disci
 
 - Authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates based off of tech debt, project priorities
-- Understands competing priorities and acts accordingly
+- Understands and balances competing priorities and acts accordingly
 - Design solutions of high complexity that are aligned with the overall architecture
 - Assists with technical discovery during planning to reduce ambiguity
 - Influences product roadmap by bringing technical insight and aligning engineering priorities with business goals

--- a/senior_engineer.md
+++ b/senior_engineer.md
@@ -14,7 +14,7 @@ I increasingly optimize beyond just my team by driving cross-team or cross-disci
 - Authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates based off of tech debt, project priorities
 - Understands and balances competing priorities and acts accordingly
-- Design solutions of high complexity that are aligned with the overall architecture
+- Design solutions that require architectural decisions, cross-team coordination, or deep domain knowledge
 - Assists with technical discovery during planning to reduce ambiguity
 - Influences product roadmap by bringing technical insight and aligning engineering priorities with business goals
 


### PR DESCRIPTION
First sorry for all the whitespace diff, fortunately github allows you to hide whitespace changes when reviewing.
<img width="670" alt="image" src="https://github.com/user-attachments/assets/b1b35e4e-d648-44e5-a5bc-27026b7d3345" />


The primary change here is the the Planning, Prioritization and Architecture section to contrast more distinction between level 3 and senior. Additionally I replaced x-y-z complexity with high-medium-low complexity because it wasn't immediately obvious to me what was meant by x-y-z.  Low-medium-high is still undefined but I feel it's more clear the intend than x-y-z.