### PR TITLE
Senior Engineers should translate product priorities to technical priorities

### DIFF
--- a/senior_engineer.md
+++ b/senior_engineer.md
@@ -12,7 +12,7 @@ A Senior Engineer increasingly optimizes beyond just their team by driving cross
 
 - Authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates considering tech debt, quality, and project priorities
-- Understands competing priorities and acts accordingly
+- Translates product priorities into technical priorities and clearly communicate those to the team
 - Design solutions that require architectural decisions, cross-team coordination, or deep domain knowledge
 - Assists with technical discovery during planning to reduce ambiguity
 - Influences product roadmap by bringing technical insight and aligning engineering priorities with business goals


### PR DESCRIPTION
# Background
We mention managing priorities in each of the engineer levels. Here's where we landed:

| Level | Prioritization expectations |
| --- | --- |
| Eng I | - Works according to priority of their tasks|
| Eng II | - Understands the priority of their tasks and acts accordingly |
| Eng III | - Understands the priority of their tasks and acts accordingly |
| Senior Engineer | - Understands competing priorities and acts accordingly |

These lines are repetitive and there is not much progression between levels. 

# Solution
For Senior Engineer level, I added a line from the [old career ladder](https://docs.google.com/spreadsheets/d/1KlW3k9enD_dits2Y316E8lhgkBWB-UaC/edit?gid=1608689845#gid=1608689845) for Senior Engineer which I think is important. 

"Translates product priorities into technical priorities and clearly communicate those to the team"