### PR TITLE
Remove 'web' specific language in Eng 1

### DIFF
--- a/engineer1.md
+++ b/engineer1.md
@@ -31,4 +31,4 @@ An Engineer I owns work within the scope of their team with specific guidance fr
 - 10% - Learn about and maintain best practices
 
 ## Experience
-- Foundational understanding of architecture, databases and operating systems
+- High level understanding of architecture, databases and operating systems


### PR DESCRIPTION
The Eng 1 experience section mentioned 'web architecture' but of course we have engineers working on various platforms, so I removed it.

~I also swapped the words "High level understanding" for "Foundational understanding" since "High level" feels like too low of a bar~