### PR TITLE
Github Pages Proof of Concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Outside Engineering Career Ladder
 
+This documentation is maintained via Github repo and hosted as a static site on Github Pages
+* [Here is the link to the source code](https://github.com/outside-docs/career-ladder)
+* [Here is the link to the static site](https://potential-garbanzo-rwz2pj1.pages.github.io/)
+
 ## All Engineers 
 - Look for ways to help and support each other.
 - Honor team commitments and respond to email/chat in a timely manner.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 - Proactively ask for feedback from teammates, graciously accept it and identify ways to act upon it.
 
 ## Role Descriptions
-- [Engineer 1](engineer1.md )
-- [Engineer 2](engineer2.md )
-- [Engineer 3](engineer3.md )
-- [Senior Engineer](senior_engineer.md )
-- [Staff Engineer](staff_engineer.md )
-- [Principal Engineer](principal_engineer.md )
+- [Engineer 1](./engineer1.md)
+- [Engineer 2](./engineer2.md)
+- [Engineer 3](./engineer3.md)
+- [Senior Engineer](./senior_engineer.md)
+- [Staff Engineer](./staff_engineer.md)
+- [Principal Engineer](./principal_engineer.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This documentation is maintained via Github repo and hosted as a static site on Github Pages
 * [Here is the link to the source code](https://github.com/outside-docs/career-ladder)
-* [Here is the link to the static site](https://potential-garbanzo-rwz2pj1.pages.github.io/)
+* [Here is the link to the static site](https://outside-docs.github.io/career-ladder/)
 
 ## All Engineers 
 - Look for ways to help and support each other.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+plugins:
+  - jekyll-relative-links
+relative_links:
+  enabled: true
+  collections: true
+include:
+  - README.md
+theme: jekyll-theme-primer

--- a/engineer1.md
+++ b/engineer1.md
@@ -1,3 +1,5 @@
+# Engineer 1
+
 ## Scope
 An Engineer I owns work within the scope of their team with specific guidance from their manager and engineering lead
 

--- a/engineer2.md
+++ b/engineer2.md
@@ -1,3 +1,5 @@
+# Engineer 2
+
 ## Scope
 
 An Engineer II owns work primarily within the scope of their team with high level guidance from their manager and engineering lead

--- a/engineer3.md
+++ b/engineer3.md
@@ -1,3 +1,5 @@
+# Engineer 3
+
 ## Scope
 
 An Engineer III owns work primarily with their direct team and cross-functional partners while driving cross-team collaboration for projects

--- a/principal_engineer.md
+++ b/principal_engineer.md
@@ -1,3 +1,5 @@
+# Principal Engineer
+
 ## Scope
 
 A Principal Engineer typically influences the technical strategy and direction of the wider engineering org. They partner closely with Product and Engineering leadership to ensure the health of the department as a whole

--- a/senior_engineer.md
+++ b/senior_engineer.md
@@ -1,3 +1,5 @@
+# Senior Engineer
+
 ## Scope
 
 A Senior Engineer increasingly optimizes beyond just their team by driving cross-team or cross-discipline initiatives - owning work in and adjacent to their primary domain

--- a/staff_engineer.md
+++ b/staff_engineer.md
@@ -1,3 +1,5 @@
+# Staff Engineer
+
 ## Scope
 
 A Staff Engineer influences the roadmaps of other teams to achieve business impacting goals. They exercise judgement that favors the priorities of the wider engineering org rather than favoring locally optimal outcomes


### PR DESCRIPTION
**Background**
This PR demonstrates hosting our markdown files using Github Pages

The configuration for this can be found in https://github.com/outside-docs/career-ladder/settings/pages

**Changes**
- I had to use a plugin to get relative links working https://github.com/nicolas-van/easy-markdown-to-github-pages without this plugin, the individual .md files would be rendered as raw text without formatting 
- I added titles to the .md files for each level. I noticed that the pages lacked titles

**Testing**
The site is deployed to https://outside-docs.github.io/career-ladder/

Right now I have the github pages configuration set to build off my branch. If/when this is merged we should revert the configuration to always build off main branch
