### PR TITLE
Improve expectations around prioritization

### DIFF
--- a/engineer1.md
+++ b/engineer1.md
@@ -7,7 +7,7 @@ An Engineer I owns work within the scope of their team with specific guidance fr
 
 ## Planning, Prioritization and Architecture
 - Reads and comments on technical solution planning artifacts (ie. RFCs, Design Diagrams)
-- Works according to priority of their tasks
+- Acts on assigned priorities
 - Designs functions, avoiding duplication across codebases and interface-breaking changes based on an understanding of the overall architecture
 	
 ## Technical Contributions

--- a/engineer3.md
+++ b/engineer3.md
@@ -12,7 +12,7 @@ An Engineer III owns work primarily with their direct team and cross-functional 
 
 - Co-author of technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates for both tickets and projects
-- Understands the priority of their tasks and acts accordingly
+- Balances the priority of their tasks with immediate team needs and acts accordingly
 - Designs solutions for problems of moderate ambiguity/complexity that are aligned with the overall architecture
 - Breaks initiatives into smaller tasks that can be understood by non-technical parties
 - Assists with technical discovery during planning to reduce ambiguity

--- a/senior_engineer.md
+++ b/senior_engineer.md
@@ -12,7 +12,7 @@ A Senior Engineer increasingly optimizes beyond just their team by driving cross
 
 - Authors technical solution planning artifacts (ie. RFCs, Design Diagrams)
 - Provides reliable estimates considering tech debt, quality, and project priorities
-- Understands competing priorities and acts accordingly
+- Translates product priorities into technical priorities and clearly communicate those to the team
 - Design solutions that require architectural decisions, cross-team coordination, or deep domain knowledge
 - Assists with technical discovery during planning to reduce ambiguity
 - Influences product roadmap by bringing technical insight and aligning engineering priorities with business goals


### PR DESCRIPTION
# Background
We currently mention prioritization in each of the engineer levels:

| Level | Prioritization expectations |
| --- | --- |
| Eng I | - Works according to priority of their tasks|
| Eng II | - Understands the priority of their tasks and acts accordingly |
| Eng III | - Understands the priority of their tasks and acts accordingly |
| Senior Engineer | - Understands competing priorities and acts accordingly |

These lines are repetitive and there is not much progression between levels. 

# Solution
Proposed changes
| Level | Prioritization expectations | reasoning |
| --- | --- | --- |
| Eng I | **- Acts on assigned priorities** | less wordy and emphasizes that priorities are mostly assigned to them at this level |
| Eng II | - Understands the priority of their tasks and acts accordingly | no change |
| Eng III | **- Balances the priority of their tasks with immediate team needs and acts accordingly** | Eng III begins the shift focus from individual contributor to be more team oriented |
| Senior Engineer | - **Translates product priorities into technical priorities and clearly communicate those to the team** | For Senior Engineer level, I added a line from the old career ladder for Senior Engineer which I think is important.